### PR TITLE
expose `show` function for ocamltter command

### DIFF
--- a/toplevel/ocamltter.mli
+++ b/toplevel/ocamltter.mli
@@ -34,6 +34,7 @@ val u : string -> status_id
 val rt : status_id -> status_id
 val re : status_id -> string -> status_id
 val qt : status_id -> string -> status_id
+val show : status_id -> Tweet.t
 val link : status_id -> string
 val qtlink : status_id -> string -> status_id
 val reqt : status_id -> string -> status_id


### PR DESCRIPTION
Currently, `help` says that there is `show` command in ocamltter, but actually `show` command is not available.

```
# print_string help;;
commands:
  l()                  list timeline
  lc N                 list timeline(N lines)
  lu "NAME"            list NAME's timeline
  m()                  list mentions (tweet containing @YOU)
  u "TEXT"             post a new message
  re ID "TEXT"         reply to ID
  del ID               delete tweet of ID
  rt ID                retweet to ID
  qt ID "TEXT"         qt ID
  qtlink ID "TEXT"     qt with link for ID
  follow "NAME"        follow NAME
  unfollow "NAME"      unfollow NAME
  fav ID               mark ID as favorites
  frt ID               fav ID and rt ID
  report_spam "NAME"   report NAME as a spam user
  s "WORD"             search tweets by a WORD
  show ID              show the tweet of ID
  link ID              link for the tweet of ID
  kwsk ID              show the convesation about ID
  setup()              (re)authorize ocamltter
  start_polling ()     start polling
  stop_polling ()      stop polling
  limit_status ()      rate limit status of API
  let CMD = ...        define a your own command CMD
  help                 print this help
  #quit                quit ocamltter
- : unit = ()
# show 774350136348663808L;;
Error: Unbound value show
```

This pull request fixes this issue by exposing `show` function defined in toplevel/ocamltter.ml.

```
# show 774350136348663808L;;
- : OCamltter_twitter.Api_intf.Tweet.t =
{ user="OCamlLang"; id=774350136348663808L;
  text="OCamlCore Forge News: https://t.co/x5OsSD39HQ is deprecated https://t.co/CbkC0hbwfk" }
```
